### PR TITLE
feat: add support to relative paths for media content

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,20 @@ Example:
 ---
 title: New Article
 description: Some description
-tags:
-  - test
-  - ci
+tags: test, ci
 license: public-domain
 ---
 # This is my new Article
 
 In this article we will learn how to setup with `blogpub`
 
-![ci-meme.jpg](./meme.jpg)
+## Relative images from the repository
+
+![ci-meme.jpg](@/assets/meme.jpg)
+
+## External Images
+
+![meme.jpg](https://sources.com/meme.jpg)
 
 ## Requirements
 
@@ -111,6 +115,17 @@ Usage:
 {{#if medium}}
 This is only for Medium
 {{/if}}
+```
+
+## Relative Images
+
+To use images contained in the same folder of the blog articles use `@` as source path. `@` will be parsed
+as the URL to the repository/<articles_folder>.
+E.g.
+```
+![image](@/img1.png)
+
+<img src="@/img2.jpg" />
 ```
 
 ## Developing

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,11 +42,20 @@ export async function run() {
     const mediumUserId = core.getInput('medium_user_id', { required: true });
     const mediumBaseUrl = core.getInput('medium_base_url', { required: false });
     const devtoApiKey = core.getInput('devto_api_key', { required: true });
+    
+    // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+    const GITHUB_SERVER_URL = process.env['GITHUB_SERVER_URL'] as string;
+    const GITHUB_REPOSITORY = process.env['GITHUB_REPOSITORY'] as string;
+    const GITHUB_REF_NAME = process.env['GITHUB_REF_NAME'] as string;
+
+    const rawGithubUrl = GITHUB_SERVER_URL
+      .replace('//github.com', '//raw.githubusercontent.com');
 
     const github = getOctokit(ghToken);
 
     const articleContent = await loadArticleContent(github, articlesFolder);
-    const article = parseArticle(articleContent);
+    const baseUrl = `${rawGithubUrl}/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/${articlesFolder}`;
+    const article = parseArticle(articleContent, baseUrl);
 
     const template = Handlebars.compile(article.content);
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -35,6 +35,12 @@ jest.mock('@actions/github', () => ({
 jest.mock('@actions/core');
 
 describe('blogpub', () => {
+  beforeAll(() => {
+    process.env['GITHUB_SERVER_URL'] = 'https://github.com';
+    process.env['GITHUB_REPOSITORY'] = 'protiumx/blogpub';
+    process.env['GITHUB_REF_NAME'] = 'main';
+  });
+
   beforeEach(jest.clearAllMocks);
 
   (getOctokit as jest.Mock).mockReturnValue(octokitMock);
@@ -247,7 +253,6 @@ describe('blogpub', () => {
   it('should upload article to dev.to and set dev.tp url output', async () => {
     const template = jest.fn(() => 'compiled');
     (Handlebars.compile as jest.Mock).mockReturnValue(template);
-
     (core.getInput as jest.Mock).mockImplementation((key: string) => {
       switch (key) {
         case 'articles_folder':
@@ -283,5 +288,7 @@ describe('blogpub', () => {
       content: 'compiled',
     });
     expect(core.setOutput).toHaveBeenCalledWith('devto_url', 'dev.to/new');
+    expect(parseArticle).toHaveBeenCalledWith(
+      'content', 'https://raw.githubusercontent.com/protiumx/blogpub/main/blogs');
   });
 });


### PR DESCRIPTION
As mentioned in #11 I wanted to provide a way to use relative images.
In this PR I introduced the possibility to use `@` as relative path to be later replaced for `https://raw.githubusercontent.com/<user>/<repo>/<articles_folder>`.

Example:
```md
![img](@/image.png)
```
is parsed into:
```md
![img](https://raw.githubusercontent.com/<user>/<repo>/<articles_folder>/image.png)
```

