### PR TITLE
refactor: improve relative paths matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The following arguments can be set:
 - `tags`: `[string | string[]]` Comma separated tags or yaml list. Note: Medium allows up to 5 tags whereas Dev.to only 4.
 - `license`: `[string]` Medium license type. Refer to [Medium API Docs](https://github.com/Medium/medium-api-docs#33-posts). **Default**: `public-domain`
 - `published`: `[boolean]`. **Default**: `true`
-- `cover_image`: `[string]` Dev.to cover image
 
 ## Template Support
 

--- a/src/api/devto.ts
+++ b/src/api/devto.ts
@@ -11,7 +11,6 @@ export async function createArticle(
   const payload = {
     article: {
       body_markdown: content,
-      cover_image: config.cover_image,
       description: config.description,
       published: config.published,
       title: config.title,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,7 +3,7 @@ import { load as loadYaml } from 'js-yaml';
 
 import { Article, ArticleConfig, MediumLicense } from './types';
 
-const RelativePathRegex = /([\.]{1,2}\/.*)/;
+const RelativePathRegex = /[\('"]([\.]{1,2}\/\S*)[\)'"]/;
 
 function getMetadataIndexes(lines: string[]): number[] {
   const indexes: number[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export enum MediumLicense {
 }
 
 export interface ArticleConfig {
-  cover_image?: string;
   description?: string;
   license?: MediumLicense;
   published?: boolean;

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -69,12 +69,10 @@ some content`;
 some content`);
   });
 
-
   it('should parse all images with relative path', () => {
     const article = `
 ---
 title: Some Title
-cover_image: ./cover.jpg
 description: New Article
 tags:
   - one
@@ -89,23 +87,32 @@ some content
 ![img](../global/img.png)
 
 <img alt="image" src="./assets/img.gif" />
+<video src='./assets/video.mp4' />
 
 ## Description
 `;
     const parsed = parseArticle(article, 'raw.github.com/protiumx/blogpub/main/articles/');
-    expect(parsed.config.cover_image).toEqual('https://raw.github.com/protiumx/blogpub/main/articles/cover.jpg');
+
     expect(parsed.config.tags).toEqual(['one', 'images']);
     expect(
       parsed.content.includes(
         '![img](https://raw.github.com/protiumx/blogpub/main/articles/assets/img.png)',
-      )).toBeTruthy();
+      ),
+    ).toBeTruthy();
     expect(
       parsed.content.includes(
         '![img](https://raw.github.com/protiumx/blogpub/main/global/img.png)',
-      )).toBeTruthy();
+      ),
+    ).toBeTruthy();
     expect(
       parsed.content.includes(
         '<img alt="image" src="https://raw.github.com/protiumx/blogpub/main/articles/assets/img.gif"',
-      )).toBeTruthy();
+      ),
+    ).toBeTruthy();
+    expect(
+      parsed.content.includes(
+        "<video src='https://raw.github.com/protiumx/blogpub/main/articles/assets/video.mp4'",
+      ),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Also removed `cover_image` as is not supported by Dev API.
Closes #21 